### PR TITLE
Use lowercase hex in UUID strings

### DIFF
--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -34,9 +34,9 @@ impl ShortUuid for Uuid {
     
         if &b[4..16] == b"\x00\x00\x10\x00\x80\x00\x00\x80\x5F\x9B\x34\xFB" {
             if b[0] == 0 && b[1] == 0 {
-                return format!("{:04X}", u16::from_be_bytes([b[2], b[3]]));
+                return format!("{:04x}", u16::from_be_bytes([b[2], b[3]]));
             } else {
-                return format!("{:08X}", u32::from_be_bytes([b[0], b[1], b[2], b[3]]));
+                return format!("{:08x}", u32::from_be_bytes([b[0], b[1], b[2], b[3]]));
             }
         }
 
@@ -71,6 +71,19 @@ mod tests {
     fn test_from_string_with_32_bit_uuid() {
         let uuid = Uuid::from_string("12345678");
         assert_eq!(uuid.to_short_string(), "12345678");
+    }
+
+    #[test]
+    fn test_lowercase_hex_output() {
+        let uuid = Uuid::from_fields(0x180d, 0, 0x1000, b"\x80\x00\x00\x80\x5F\x9B\x34\xFB");
+        assert_eq!(uuid.to_short_string(), "180d");
+    }
+
+    #[test]
+    fn test_full_uuid_string_lowercase() {
+        let uuid = Uuid::from_short(0x180d);
+        let full = uuid.to_string();
+        assert_eq!(full, "0000180d-0000-1000-8000-00805f9b34fb");
     }
 
     #[test]


### PR DESCRIPTION
nRF Connect wasn't recognizing the Heart Rate Service (0x180D). It showed up as "Unknown Service" instead. Seems like the issue is that `to_short_string()` outputs uppercase hex (180D), but nRF's database expects lowercase (180d).

RFC 4122 mentions UUIDs _should_ use lowercase a-f, even though Bluetooth spec doesn't care about case.
Changed the format strings to lowercase so this works with tools that are picky about it.

- Changed {:04X} to {:04x} and {:08X} to {:08x}
- Added tests for lowercase output

Tested on macOS (Peripheral) + nRF Connect (iOS - Central)