### PR TITLE
feat: Add manufacturer_data support for start_advertising

### DIFF
--- a/src/peripheral/bluez/mod.rs
+++ b/src/peripheral/bluez/mod.rs
@@ -108,8 +108,11 @@ impl PeripheralImpl for Peripheral {
         return Ok(result > 0 && self.adv_handle.is_some());
     }
 
-    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid]) -> Result<(), Error> {
-        let manufacturer_data = BTreeMap::new();
+    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid], manufacturer_data_arg: Option<(u16, Vec<u8>)>) -> Result<(), Error> {
+        let mut manufacturer_data = BTreeMap::new();
+        if let Some((company_id, data)) = manufacturer_data_arg {
+            manufacturer_data.insert(company_id, data);
+        }
 
         let mut services: BTreeSet<Uuid> = BTreeSet::new();
         for uuid in uuids {

--- a/src/peripheral/corebluetooth/mod.rs
+++ b/src/peripheral/corebluetooth/mod.rs
@@ -49,12 +49,13 @@ impl PeripheralImpl for Peripheral {
         return responder_rx.await?;
     }
 
-    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid]) -> Result<(), Error> {
+    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid], manufacturer_data: Option<(u16, Vec<u8>)>) -> Result<(), Error> {
         let (responder, responder_rx) = oneshot::channel();
         self.manager_tx
             .send(ManagerEvent::StartAdvertising {
                 name: name.to_string(),
                 uuids: uuids.to_vec(),
+                manufacturer_data,
                 responder,
             })
             .await?;

--- a/src/peripheral/corebluetooth/peripheral_manager.rs
+++ b/src/peripheral/corebluetooth/peripheral_manager.rs
@@ -7,7 +7,7 @@ use crate::gatt::service::Service;
 use objc2::msg_send_id;
 use objc2::{rc::Retained, runtime::AnyObject, ClassType};
 use objc2_core_bluetooth::{
-    CBAdvertisementDataLocalNameKey, CBAdvertisementDataServiceUUIDsKey, CBCharacteristic,
+    CBAdvertisementDataLocalNameKey, CBAdvertisementDataServiceUUIDsKey, CBAdvertisementDataManufacturerDataKey, CBCharacteristic,
     CBManager, CBManagerAuthorization, CBManagerState, CBMutableCharacteristic, CBMutableService,
     CBPeripheralManager,
 };
@@ -31,6 +31,7 @@ pub(crate) enum ManagerEvent {
     StartAdvertising {
         name: String,
         uuids: Vec<Uuid>,
+        manufacturer_data: Option<(u16, Vec<u8>)>,
         responder: oneshot::Sender<Result<(), Error>>,
     },
     StopAdvertising {
@@ -108,9 +109,10 @@ impl PeripheralManager {
                 ManagerEvent::StartAdvertising {
                     name,
                     uuids,
+                    manufacturer_data,
                     responder,
                 } => {
-                    let _ = responder.send(self.start_advertising(&name, &uuids).await);
+                    let _ = responder.send(self.start_advertising(&name, &uuids, manufacturer_data).await);
                 }
                 ManagerEvent::StopAdvertising { responder } => {
                     let _ = responder.send(Ok(self.stop_advertising()));
@@ -136,7 +138,7 @@ impl PeripheralManager {
         }
     }
 
-    async fn start_advertising(self: &Self, name: &str, uuids: &[Uuid]) -> Result<(), Error> {
+    async fn start_advertising(self: &Self, name: &str, uuids: &[Uuid], manufacturer_data: Option<(u16, Vec<u8>)>) -> Result<(), Error> {
         if self
             .peripheral_delegate
             .is_waiting_for_advertisement_result()
@@ -158,6 +160,14 @@ impl PeripheralManager {
             objects.push(Retained::cast(NSArray::from_vec(
                 uuids.iter().map(|u| uuid_to_cbuuid(u.clone())).collect(),
             )));
+
+            if let Some((company_id, data)) = manufacturer_data {
+                keys.push(CBAdvertisementDataManufacturerDataKey);
+                let mut combined_data = Vec::with_capacity(2 + data.len());
+                combined_data.extend_from_slice(&company_id.to_le_bytes());
+                combined_data.extend_from_slice(&data);
+                objects.push(Retained::cast(NSData::from_vec(combined_data)));
+            }
         }
 
         let advertising_data: Retained<NSDictionary<NSString, AnyObject>> =

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -31,7 +31,7 @@ pub trait PeripheralImpl: Send + Sync {
 
     async fn is_advertising(&mut self) -> Result<bool, Error>;
 
-    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid]) -> Result<(), Error>;
+    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid], manufacturer_data: Option<(u16, Vec<u8>)>) -> Result<(), Error>;
 
     async fn stop_advertising(&mut self) -> Result<(), Error>;
 

--- a/src/peripheral/winrt/mod.rs
+++ b/src/peripheral/winrt/mod.rs
@@ -31,7 +31,7 @@ impl PeripheralImpl for Peripheral {
         Ok(self.peripheral_manager.is_powered().await?)
     }
 
-    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid]) -> Result<(), Error> {
+    async fn start_advertising(&mut self, name: &str, uuids: &[Uuid], _manufacturer_data: Option<(u16, Vec<u8>)>) -> Result<(), Error> {
         if let Err(err) = self.peripheral_manager.start_advertising(name, uuids).await {
             return Err(Error::from(err));
         }


### PR DESCRIPTION
This PR adds `manufacturer_data` parameter to the `start_advertising` interface, allowing broadcast of battery, pairing mode, and custom payloads.

- **CoreBluetooth**: Implemented via `CBAdvertisementDataManufacturerDataKey`.
- **BlueZ**: Implemented via `Advertisement::manufacturer_data`.
- **WinRT**: Signature updated (currently ignored/fallback).