### PR TITLE
feat: allow CoreBluetooth peripheral restart on Apple Platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,6 @@ dependencies = [
  "objc2",
  "objc2-core-bluetooth",
  "objc2-foundation",
- "once_cell",
  "pretty_env_logger",
  "tokio",
  "uuid",
@@ -578,12 +577,6 @@ checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "pin-project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ tokio = { version = "1.42.0", features = [
 ] }
 uuid = "1.11.0"
 log = "0.4"
-once_cell = "1.20.2"
 async-trait = "0.1.83"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/peripheral/corebluetooth/mac_utils.rs
+++ b/src/peripheral/corebluetooth/mac_utils.rs
@@ -2,7 +2,7 @@ use std::os::raw::{c_char, c_void};
 
 pub const DISPATCH_QUEUE_SERIAL: *const c_void = 0 as *const c_void;
 
-#[link(name = "AppKit", kind = "framework")]
+#[cfg_attr(target_os = "macos", link(name = "AppKit", kind = "framework"))]
 #[link(name = "Foundation", kind = "framework")]
 #[link(name = "CoreBluetooth", kind = "framework")]
 extern "C" {

--- a/src/peripheral/corebluetooth/peripheral_manager.rs
+++ b/src/peripheral/corebluetooth/peripheral_manager.rs
@@ -12,7 +12,6 @@ use objc2_core_bluetooth::{
     CBPeripheralManager,
 };
 use objc2_foundation::{NSArray, NSData, NSDictionary, NSString};
-use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::thread;
@@ -47,24 +46,17 @@ pub(crate) enum ManagerEvent {
     },
 }
 
-static PERIPHERAL_THREAD: OnceCell<()> = OnceCell::new();
-
-// Handle Peripheral Manager and all communication in a separate thread
 pub fn run_peripheral_thread(sender: Sender<PeripheralEvent>, listener: Receiver<ManagerEvent>) {
-    PERIPHERAL_THREAD.get_or_init(|| {
-        thread::spawn(move || {
-            let runtime = runtime::Builder::new_current_thread().enable_time().build();
-            if runtime.is_err() {
-                log::error!("Failed to create runtime");
-                return;
-            }
-            runtime.unwrap().block_on(async move {
-                let mut peripheral_manager = PeripheralManager::new(sender, listener);
-                loop {
-                    peripheral_manager.handle_event().await;
-                }
-            })
-        });
+    thread::spawn(move || {
+        let runtime = runtime::Builder::new_current_thread().enable_time().build();
+        if runtime.is_err() {
+            log::error!("Failed to create runtime");
+            return;
+        }
+        runtime.unwrap().block_on(async move {
+            let mut peripheral_manager = PeripheralManager::new(sender, listener);
+            while peripheral_manager.handle_event().await {}
+        })
     });
 }
 
@@ -96,7 +88,7 @@ impl PeripheralManager {
         }
     }
 
-    async fn handle_event(&mut self) {
+    async fn handle_event(&mut self) -> bool {
         if let Some(event) = self.manager_event.recv().await {
             let _ = match event {
                 ManagerEvent::IsPowered { responder } => {
@@ -126,6 +118,9 @@ impl PeripheralManager {
                     let _ = responder.send(self.update_characteristic(characteristic, value).await);
                 }
             };
+            true
+        } else {
+            false
         }
     }
 


### PR DESCRIPTION
## Summary

  - Link AppKit only on macOS so iOS builds no longer fail with
  `framework 'AppKit' not found`
  - Remove the one-time CoreBluetooth manager thread guard so a new
  manager can start after the previous channel closes
  - Drop the unused `once_cell` dependency

  ## Why

  Stopping broadcast closes the manager channel. Previously, the
  global `OnceCell` prevented the CoreBluetooth manager thread from
  being started again, so the next `Peripheral::new(...)` used a
  fresh sender without a live receiver and failed with
  `BlePeripheralRust ChannelError channel closed`.

  ## Verification

  - `cargo check --locked`
  - `rustfmt --edition 2021 --check src/peripheral/corebluetooth/
  mac_utils.rs src/peripheral/corebluetooth/peripheral_manager.rs`
